### PR TITLE
[TASK] Populate Dotenv from environment variables

### DIFF
--- a/src/Env.php
+++ b/src/Env.php
@@ -16,19 +16,19 @@ class Env
     public function load(?string $configFile = null, ?string $envKey = null): void
     {
         if (self::$envLoaded === false) {
+            $dotEnv = new Dotenv();
             $configFile = $configFile ?? $this->projectRootAbsolutePath() . '/.env';
             if (file_exists($configFile)) {
-                $dotEnv = new Dotenv();
                 if (method_exists($dotEnv, 'loadEnv')) {
                     $dotEnv->loadEnv($configFile, $envKey);
                 } else {
                     $dotEnv->load($configFile);
                 }
-                self::$envLoaded = true;
             } else {
-                throw new RuntimeException('Missing config file. Searching in: '
-                    . "\n" . $configFile, 1500717945887);
+                $env = getenv();
+                $dotEnv->populate($env);
             }
+            self::$envLoaded = true;
         }
     }
 


### PR DESCRIPTION
This PR allows the deployer instance to fall back to environment variables if no `.env` file is available, improving compatibility with Docker and similar setups.

A dedicated loader setting for this feature may not be necessary. If a misconfiguration causes the .env file to be missing, the fallback will be used, and the resulting error (e.g., "INSTANCE var is not set") should make the issue clear.